### PR TITLE
Add `babel-runtime` as prod dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "amqp-connection-manager": "^2.3.0",
     "amqplib": "^0.5.2",
+    "babel-runtime": "^6.26.0",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.13"
   },


### PR DESCRIPTION
So that it's pulled in on `yarn install --production`