### PR TITLE
Fix silent channel setup failures by adding error handler on consume …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bull-amqp",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "A (almost) drop-in replacement for the Bull queue, backed by the AMQP protocol",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -186,7 +186,11 @@ class Queue extends EventEmitter {
 
   private _ensureConsumeChannelOpen(queue: string): ChannelWrapper {
     if (!(queue in this._consumeChan)) {
-      this._consumeChan[queue] = this._conn!.createChannel();
+      const chan = this._conn!.createChannel();
+      chan.on('error', (err: Error) => {
+        this.emit('channel:error', { queue, err });
+      });
+      this._consumeChan[queue] = chan;
     }
 
     return this._consumeChan[queue];


### PR DESCRIPTION
Without an error handler on each ChannelWrapper created for a consumer queue, any failure during amqp-connection-manager's addSetup replay on reconnect is silently swallowed. This surfaces those errors via a 'channel:error' event so callers can observe and react to channel-level failures per queue.