### PR TITLE
fix event name mapping for connection events, tidy up the stopAcceptingNewJobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bull-amqp",
-  "version": "1.11.2",
+  "version": "1.11.4",
   "description": "A (almost) drop-in replacement for the Bull queue, backed by the AMQP protocol",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Queue.integration.test.ts
+++ b/src/Queue.integration.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import * as connections from 'amqp-connection-manager';
 import type { AmqpConnectionManager } from 'amqp-connection-manager';
 import Queue, { Job } from './Queue';

--- a/src/Queue.test.ts
+++ b/src/Queue.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import { EventEmitter } from 'events';
 
 // Mock amqp-connection-manager before importing Queue
@@ -33,6 +34,11 @@ interface MockChannelWrapper extends EventEmitter {
   waitForConnect: jest.Mock;
   sendToQueue: jest.Mock;
   addSetup: jest.Mock;
+  removeSetup: jest.Mock;
+  consume: jest.Mock;
+  cancelAll: jest.Mock;
+  ack: jest.Mock;
+  nack: jest.Mock;
   close: jest.Mock;
 }
 
@@ -69,6 +75,21 @@ const createMockChannelWrapper = (channel: MockChannel): MockChannelWrapper => {
   wrapper.addSetup = jest.fn().mockImplementation(async (fn: (chan: MockChannel) => Promise<void>) => {
     await fn(channel);
   });
+  wrapper.removeSetup = jest.fn().mockResolvedValue(undefined);
+  wrapper.consume = jest.fn().mockImplementation((queue: string, callback: ConsumeCallback, opts?: { prefetch?: number }) => {
+    if (opts?.prefetch !== undefined) {
+      channel.prefetch(opts.prefetch);
+    }
+    consumerCallbacks.set(queue, callback);
+    consumerTagCounter++;
+    channel.consume(queue, callback);
+    return Promise.resolve({ consumerTag: `consumer-tag-${consumerTagCounter}` });
+  });
+  wrapper.cancelAll = jest.fn().mockImplementation(async () => {
+    await channel.cancel('mock-tag');
+  });
+  wrapper.ack = jest.fn().mockImplementation((msg) => channel.ack(msg));
+  wrapper.nack = jest.fn().mockImplementation((msg: MockMessage, allUpTo: boolean, requeue: boolean) => channel.nack(msg, allUpTo, requeue));
   wrapper.close = jest.fn().mockResolvedValue(undefined);
   return wrapper;
 };
@@ -168,7 +189,7 @@ describe('Queue', () => {
       });
 
       setImmediate(() => {
-        mockConnection.emit('error', testError);
+        mockConnection.emit('connectFailed', { err: testError });
       });
     });
 
@@ -182,7 +203,7 @@ describe('Queue', () => {
       });
 
       setImmediate(() => {
-        mockConnection.emit('close', testError);
+        mockConnection.emit('disconnect', { err: testError });
       });
     });
   });
@@ -352,7 +373,8 @@ describe('Queue', () => {
 
       await callback!(msg);
 
-      expect(mockChannel.sendToQueue).toHaveBeenCalledWith(
+      const consumeChan = mockConnection._channels[1];
+      expect(consumeChan.sendToQueue).toHaveBeenCalledWith(
         'reply-queue',
         expect.any(Buffer),
         { correlationId: 'corr-123' }
@@ -427,6 +449,47 @@ describe('Queue', () => {
       const sendToQueueCalls = mainChannel.sendToQueue.mock.calls;
       const dlqCall = sendToQueueCalls.find((call: unknown[]) => call[0] === 'bull-dead-letter-queue');
       expect(dlqCall).toBeDefined();
+    });
+
+    it('should isolate consume channels — each process() call gets its own channel', async () => {
+      const queue = new Queue(queueName, connectionString);
+
+      await queue.process('queue-a', jest.fn().mockResolvedValue('done'));
+      await queue.process('queue-b', jest.fn().mockResolvedValue('done'));
+
+      // _channels[0] is the main publish channel created in _setup()
+      // _channels[1] and [2] are the consume channels, one per process() call
+      const [mainChan, chanA, chanB] = mockConnection._channels;
+
+      expect(mockConnection._channels).toHaveLength(3);
+
+      // Each consume channel registered its own consumer
+      expect(chanA.consume).toHaveBeenCalledWith('bull-queue-a', expect.any(Function), expect.any(Object));
+      expect(chanB.consume).toHaveBeenCalledWith('bull-queue-b', expect.any(Function), expect.any(Object));
+
+      // Consume channels have no addSetup calls — consumers go through ChannelWrapper.consume(), not addSetup
+      expect(chanA.addSetup).not.toHaveBeenCalled();
+      expect(chanB.addSetup).not.toHaveBeenCalled();
+
+      // Main channel has no consumers registered directly on it
+      expect(mainChan.consume).not.toHaveBeenCalled();
+    });
+
+    it('should isolate RPC setup from consume channels', async () => {
+      const queue = new Queue(queueName, connectionString);
+
+      await queue.process(jest.fn().mockResolvedValue('done'));
+      await expect(queue.call({ data: true }, { timeout: 50 })).rejects.toThrow('Timeout');
+
+      const [mainChan, consumeChan] = mockConnection._channels;
+
+      // RPC addSetup belongs only to the main channel
+      expect(mainChan.addSetup).toHaveBeenCalledTimes(1);
+      expect(consumeChan.addSetup).not.toHaveBeenCalled();
+
+      // Consumer belongs only to the consume channel
+      expect(consumeChan.consume).toHaveBeenCalledTimes(1);
+      expect(mainChan.consume).not.toHaveBeenCalled();
     });
   });
 
@@ -551,6 +614,27 @@ describe('Queue', () => {
       expect(sendToQueueCall[2]).toHaveProperty('correlationId');
       expect(sendToQueueCall[2]).toHaveProperty('replyTo');
     });
+
+    it('should register RPC setup once and reuse across reconnects', async () => {
+      const queue = new Queue(queueName, connectionString);
+      const mainChan = mockConnection._channels[0];
+
+      // First call registers the setup exactly once
+      await expect(queue.call({ request: 'data' }, { timeout: 50 })).rejects.toThrow('Timeout');
+      expect(mainChan.addSetup).toHaveBeenCalledTimes(1);
+      expect(mainChan.removeSetup).not.toHaveBeenCalled();
+
+      // Multiple reconnects — no new registrations, no removals
+      mockConnection.emit('connect', {});
+      mockConnection.emit('connect', {});
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mainChan.addSetup).toHaveBeenCalledTimes(1);
+      expect(mainChan.removeSetup).not.toHaveBeenCalled();
+
+      // Subsequent calls reuse the existing setup
+      await expect(queue.call({ request: 'data' }, { timeout: 50 })).rejects.toThrow('Timeout');
+      expect(mainChan.addSetup).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('stopAcceptingNewJobs()', () => {
@@ -563,12 +647,21 @@ describe('Queue', () => {
       // Verify consumer was registered
       expect(mockChannel.consume).toHaveBeenCalled();
 
-      // Wait for addSetup to complete (it's not awaited in process())
-      await new Promise((resolve) => setImmediate(resolve));
-
       await queue.stopAcceptingNewJobs();
 
       expect(mockChannel.cancel).toHaveBeenCalled();
+    });
+
+    it('should call cancelAll on the consume channel wrapper', async () => {
+      const queue = new Queue(queueName, connectionString);
+      const handler = jest.fn().mockResolvedValue('done');
+
+      await queue.process(handler);
+
+      const consumeChan = mockConnection._channels[1];
+      await queue.stopAcceptingNewJobs();
+
+      expect(consumeChan.cancelAll).toHaveBeenCalled();
     });
 
     it('should handle empty consumer list', async () => {

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -284,7 +284,6 @@ class Queue extends EventEmitter {
 
         chan.ack(msg);
       } catch (err) {
-        chan.nack(msg, false, false);
         const pubChan = this._chan!;
         const errors = (data['$$errors'] as unknown[]) || [];
         const errorWithFormat = [...errors, formatError(err)];
@@ -308,6 +307,8 @@ class Queue extends EventEmitter {
             this._getPublishOptions()
           );
         }
+
+        chan.nack(msg, false, false);
       }
     }, { prefetch: concurrency });
   }

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -71,8 +71,8 @@ class Queue extends EventEmitter {
   private _queuesExist: Record<string, boolean> = Object.create(null);
   private _replyHandlers: Map<string, (result: unknown) => void> = new Map();
   private _replyQueue: Promise<string> | null = null;
-  private _consumerTags: Record<string, string> = Object.create(null);
-  private _stopped: boolean = false;
+  private _rpcSetupRegistered: boolean = false;
+  private _resolveRpcQueue: ((queue: string) => void) | null = null;
 
   constructor(name: string, connectionString: string | Options, options?: Options | string);
   constructor(name: string, options: Options);
@@ -125,8 +125,8 @@ class Queue extends EventEmitter {
     this._consumeChan = Object.create(null);
     this._replyHandlers = new Map();
     this._replyQueue = null;
-    this._consumerTags = Object.create(null);
-    this._stopped = false;
+    this._rpcSetupRegistered = false;
+    this._resolveRpcQueue = null;
   }
 
   private async _setup(): Promise<void> {
@@ -142,17 +142,21 @@ class Queue extends EventEmitter {
     this._chan = conn.createChannel();
 
     conn.on('connect', () => {
-      // after reconnect we need to reset _replyQueue to restore work of .call
-      // otherwise await this._replyQueue - will stuck
-      this._replyQueue = null;
       this.emit('connection:connected');
     });
 
-    conn.on('error', (err: Error) => {
+    conn.on('connectFailed', ({ err }: { err: Error }) => {
       this.emit('connection:error', err);
     });
 
-    conn.on('close', (err: Error) => {
+    conn.on('disconnect', ({ err }: { err: Error }) => {
+      // Invalidate stale reply queue so call() waits for addSetup to recreate it
+      // on the new channel rather than publishing with a dead exclusive queue name.
+      if (this._rpcSetupRegistered) {
+        let resolve!: (queue: string) => void;
+        this._replyQueue = new Promise<string>((r) => { resolve = r; });
+        this._resolveRpcQueue = resolve;
+      }
       this.emit('connection:close', err);
     });
   }
@@ -250,74 +254,62 @@ class Queue extends EventEmitter {
 
     await this._ensureQueueExists(queue, chan);
 
-    await chan.addSetup(async (chan: Channel) => {
-      if (this._stopped) return;
-      await chan.prefetch(concurrency);
-      const { consumerTag } = await chan.consume(queue, async (msg: ConsumeMessage | null) => {
-        if (!msg) {
-          return;
+    await chan.consume(queue, async (msg: ConsumeMessage) => {
+      let data: Record<string, unknown> = {};
+      try {
+        data = JSON.parse(msg.content.toString());
+
+        const job: Job<T> = {
+          data: data as unknown as T,
+        };
+
+        const [result] = await Promise.all([
+          promiseHandler(job),
+          this._options.minProcessingTimeMs !== undefined
+            ? setTimeout(this._options.minProcessingTimeMs)
+            : Promise.resolve(),
+        ]);
+
+        // see if we need to reply
+        if (
+          typeof result !== 'undefined' &&
+          typeof msg.properties === 'object' &&
+          typeof msg.properties.replyTo !== 'undefined' &&
+          typeof msg.properties.correlationId !== 'undefined'
+        ) {
+          await chan.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(result), 'utf8'), {
+            correlationId: msg.properties.correlationId,
+          });
         }
 
-        let data: Record<string, unknown> = {};
-        try {
-          data = JSON.parse(msg.content.toString());
+        chan.ack(msg);
+      } catch (err) {
+        chan.nack(msg, false, false);
+        const pubChan = this._chan!;
+        const errors = (data['$$errors'] as unknown[]) || [];
+        const errorWithFormat = [...errors, formatError(err)];
+        const withWithErrors = { ...data, '$$errors': errorWithFormat };
 
-          const job: Job<T> = {
-            data: data as unknown as T,
-          };
+        if (errorWithFormat.length < 3) {
+          this.emit('single-failure', err);
+          await pubChan.sendToQueue(
+            queue,
+            Buffer.from(JSON.stringify(withWithErrors)),
+            this._getPublishOptions()
+          );
+        } else {
+          this.emit('failure', err);
+          const dlqQueue = this._getQueueName('dead-letter-queue');
+          await this._ensureQueueExists(dlqQueue, pubChan);
 
-          const [result] = await Promise.all([
-            promiseHandler(job),
-            this._options.minProcessingTimeMs !== undefined
-              ? setTimeout(this._options.minProcessingTimeMs)
-              : Promise.resolve(),
-          ]);
-
-          // see if we need to reply
-          if (
-            typeof result !== 'undefined' &&
-            typeof msg.properties === 'object' &&
-            typeof msg.properties.replyTo !== 'undefined' &&
-            typeof msg.properties.correlationId !== 'undefined'
-          ) {
-            await chan.sendToQueue(msg.properties.replyTo, Buffer.from(JSON.stringify(result), 'utf8'), {
-              correlationId: msg.properties.correlationId,
-            });
-          }
-
-          chan.ack(msg);
-        } catch (err) {
-          chan.nack(msg, false, false);
-          const pubChan = this._chan!;
-          const errors = (data['$$errors'] as unknown[]) || [];
-          const newErrors = [...errors, formatError(err)];
-          const newData = {
-            ...data,
-            ['$$errors']: newErrors,
-          };
-
-          if (newErrors.length < 3) {
-            this.emit('single-failure', err);
-            await pubChan.sendToQueue(
-              queue,
-              Buffer.from(JSON.stringify(newData)),
-              this._getPublishOptions()
-            );
-          } else {
-            this.emit('failure', err);
-            const dlqQueue = this._getQueueName('dead-letter-queue');
-            await this._ensureQueueExists(dlqQueue, pubChan);
-
-            await pubChan.sendToQueue(
-              dlqQueue,
-              Buffer.from(JSON.stringify(newData)),
-              this._getPublishOptions()
-            );
-          }
+          await pubChan.sendToQueue(
+            dlqQueue,
+            Buffer.from(JSON.stringify(withWithErrors)),
+            this._getPublishOptions()
+          );
         }
-      });
-      this._consumerTags[queue] = consumerTag;
-    });
+      }
+    }, { prefetch: concurrency });
   }
 
   private async _fireJob(
@@ -372,37 +364,39 @@ class Queue extends EventEmitter {
 
   private async _ensureRpcQueue(): Promise<string> {
     if (!this._replyQueue) {
-      let resolveQueue: (queue: string) => void;
-      this._replyQueue = new Promise<string>((resolve) => {
-        resolveQueue = resolve;
-      });
-
       const replyHandlers = this._replyHandlers;
+      let resolve!: (queue: string) => void;
+      this._replyQueue = new Promise<string>((r) => { resolve = r; });
+      this._resolveRpcQueue = resolve;
 
-      // Use addSetup so the reply queue and consumer survive channel reconnections.
-      // runOnceForChannel was previously used here but it creates a one-shot consumer
-      // on the raw channel that is lost if the channel is recreated.
-      await this._chan!.addSetup(async (chan: Channel) => {
-        const q = await chan.assertQueue('', { exclusive: true });
-        resolveQueue(q.queue);
+      if (!this._rpcSetupRegistered) {
+        this._rpcSetupRegistered = true;
 
-        chan.consume(
-          q.queue,
-          (msg: ConsumeMessage | null) => {
-            if (!msg) return;
-            const correlationId = msg.properties.correlationId;
-            const replyHandler = replyHandlers.get(correlationId);
-
-            if (replyHandler) {
-              replyHandler(JSON.parse(msg.content.toString()));
-              replyHandlers.delete(correlationId);
-            }
-          },
-          {
-            noAck: true,
+        await this._chan!.addSetup(async (chan: Channel): Promise<void> => {
+          const q = await chan.assertQueue('', { exclusive: true });
+          // Replace pending/stale promise with resolved one, then unblock any waiters.
+          this._replyQueue = Promise.resolve(q.queue);
+          if (this._resolveRpcQueue) {
+            this._resolveRpcQueue(q.queue);
+            this._resolveRpcQueue = null;
           }
-        );
-      });
+
+          chan.consume(
+            q.queue,
+            (msg: ConsumeMessage | null) => {
+              if (!msg) return;
+              const correlationId = msg.properties.correlationId;
+              const replyHandler = replyHandlers.get(correlationId);
+
+              if (replyHandler) {
+                replyHandler(JSON.parse(msg.content.toString()));
+                replyHandlers.delete(correlationId);
+              }
+            },
+            { noAck: true }
+          );
+        });
+      }
     }
 
     return await this._replyQueue!;
@@ -451,21 +445,8 @@ class Queue extends EventEmitter {
   }
 
   async stopAcceptingNewJobs(): Promise<void> {
-    this._stopped = true;
-    const queues = Object.keys(this._consumeChan || {});
-    await Promise.all(
-      queues.map(async (queue) => {
-        const chanWrapper = this._consumeChan[queue];
-        const tag = this._consumerTags && this._consumerTags[queue];
-        if (!chanWrapper || !tag) return;
-        await runOnceForChannel(chanWrapper, async (chan: Channel) => {
-          try {
-            await chan.cancel(tag);
-          } catch {
-            // ignore errors from cancel if already closed/canceled
-          }
-        });
-      })
+    await Promise.all(Object.values(this._consumeChan).map(
+      (ch) => ch.cancelAll())
     );
   }
 
@@ -486,9 +467,6 @@ class Queue extends EventEmitter {
   }
 
   async close(): Promise<void> {
-    // Stop accepting new jobs first
-    this._stopped = true;
-
     // Close all consume channels
     const consumeChannels = Object.values(this._consumeChan);
     for (const chan of consumeChannels) {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -9,7 +9,6 @@ export async function waitForRabbitMQ(maxAttempts = 30): Promise<void> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       const conn = connections.connect(connectionString);
-      const channel = conn.createChannel();
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -27,7 +26,6 @@ export async function waitForRabbitMQ(maxAttempts = 30): Promise<void> {
         });
       });
 
-      await channel.close();
       await conn.close();
       return;
     } catch (err) {

--- a/src/test/setup.integration.ts
+++ b/src/test/setup.integration.ts
@@ -1,3 +1,4 @@
+/// <reference types="jest" />
 import { waitForRabbitMQ, getConnectionString } from './helpers';
 
 // Suppress "Channel ended" errors that occur during Jest teardown


### PR DESCRIPTION
- Event names were not mapped correctly, likely from the amqp-connection-manager upgrade:
  - `error` ➡️ `connectFailed`
  - `close` ➡️ `disconnect`
- Consumer reconnection — process() used addSetup + raw chan.consume(). On reconnect, addSetup re-ran but the raw consume call did not, silently killing consumers. Replaced with ChannelWrapper.consume(), which registers consumers in ACM's internal reconnect registry and resubscribes automatically.
- Replace manual _consumerTags tracking and _stopped flag with `ChannelWrapper.consume()` + `cancelAll()` — `amqp-connection-manager` (ACM) manages consumer tag lifecycle internally, including re-registration after reconnect